### PR TITLE
7x7 MBL points with less interference

### DIFF
--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -1,3 +1,4 @@
+// comment to be able to write something...please ignore it
 #include "Marlin.h"
 #include "Configuration.h"
 #include "ConfigurationStore.h"


### PR DESCRIPTION
Hi Pavel, first thanks for the pull and improvement of the 7x7 MBL.
I tried to understand your concerns about the magnets interference to the PINDA readings. I think i found a pattern where the probe points aren't too close to the magnets.
- If the 1st MBL probe point starts at x6 y24 (nozzle is x1 y1) and then with a spacing of 34mm in both directions the back right point will be at x228 y210 (nozzle x205 y205).
- Only 5 probe points will overlap the magnet cutouts.
  - Probe point x126 y74 has a ~2mm overlapping to the cutout
  - Probe point x126 y142 has a ~1.5 mm overlapping to the cutout
  - Probe point x160 y108 has a ~0.5 mm overlapping to the cutout
  - Probe point x92 y108 has a ~0.25 mm overlapping to the cutout
  - Probe point x58 y108 has a ~0.25 mm overlapping to the cutout

As the magnets are square, just at 2 probe points could interfere/overlap magnets.
- Probe point x126 y74
- Probe point x126 y142

![7x7 mbl points](https://user-images.githubusercontent.com/25530011/54031595-7df80800-41af-11e9-9eb5-113ebd873397.png)
Here a link to it my Fusion attempt to find optimal MBL probe points https://a360.co/2TrpuLp